### PR TITLE
Fix issue with inlined gst_caps_ref/gst_caps_unref function

### DIFF
--- a/src/org/gstreamer/Caps.java
+++ b/src/org/gstreamer/Caps.java
@@ -21,6 +21,7 @@
 package org.gstreamer;
 
 import org.gstreamer.lowlevel.GstCapsAPI;
+import org.gstreamer.lowlevel.GstMiniObjectAPI;
 import org.gstreamer.lowlevel.GstNative;
 import org.gstreamer.lowlevel.RefCountedObject;
 
@@ -60,9 +61,10 @@ import com.sun.jna.Pointer;
  */
 public class Caps extends RefCountedObject {
     public static final String GTYPE_NAME = "GstCaps";
-    
-    private static final GstCapsAPI gst = GstNative.load(GstCapsAPI.class);
-    
+
+    private static interface API extends GstCapsAPI, GstMiniObjectAPI {}
+    private static final API gst = GstNative.load(API.class);
+
     /**
      * Creates a new Caps that is empty.  
      * That is, the returned Caps contains no media formats.
@@ -418,13 +420,13 @@ public class Caps extends RefCountedObject {
         return other == this || isEqual((Caps) other);
     }
     protected void ref() {
-        gst.gst_caps_ref(this);
+        gst.gst_mini_object_ref(this);
     }
     protected void unref() {
-        gst.gst_caps_unref(this);
+        gst.gst_mini_object_unref(this);
     }
     protected void disposeNativeHandle(Pointer ptr) {
-        gst.gst_caps_unref(ptr);
+        gst.gst_mini_object_unref(ptr);
     }
 
     

--- a/src/org/gstreamer/lowlevel/GstCapsAPI.java
+++ b/src/org/gstreamer/lowlevel/GstCapsAPI.java
@@ -45,9 +45,6 @@ public interface GstCapsAPI extends com.sun.jna.Library {
     @CallerOwnsReturn Caps gst_caps_new_simple(String media_type, String fieldName, Object... args);
     @CallerOwnsReturn Caps gst_caps_new_full(Structure... data);
     
-    Pointer gst_caps_ref(Caps caps);
-    void gst_caps_unref(Caps caps);
-    void gst_caps_unref(Pointer caps);
     @CallerOwnsReturn Pointer ptr_gst_caps_copy(Caps caps);
     @CallerOwnsReturn Pointer ptr_gst_caps_from_string(String string);
     @CallerOwnsReturn Caps gst_caps_copy(Caps caps);

--- a/src/org/gstreamer/lowlevel/GstMiniObjectAPI.java
+++ b/src/org/gstreamer/lowlevel/GstMiniObjectAPI.java
@@ -20,13 +20,12 @@
 
 package org.gstreamer.lowlevel;
 
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
 import org.gstreamer.MiniObject;
-import org.gstreamer.lowlevel.GObjectAPI.GTypeInstance;
 import org.gstreamer.lowlevel.annotations.CallerOwnsReturn;
 import org.gstreamer.lowlevel.annotations.Invalidate;
 
-import com.sun.jna.NativeLong;
-import com.sun.jna.Pointer;
 import java.util.Arrays;
 import java.util.List;
 
@@ -36,8 +35,8 @@ import java.util.List;
 public interface GstMiniObjectAPI extends com.sun.jna.Library {
     GstMiniObjectAPI GSTMINIOBJECT_API = GstNative.load(GstMiniObjectAPI.class);
 
-    void gst_mini_object_ref(MiniObject ptr);
-    void gst_mini_object_unref(MiniObject ptr);
+    void gst_mini_object_ref(RefCountedObject ptr);
+    void gst_mini_object_unref(RefCountedObject ptr);
     void gst_mini_object_unref(Pointer ptr);
     @CallerOwnsReturn Pointer ptr_gst_mini_object_copy(MiniObject mini_object);
     @CallerOwnsReturn MiniObject gst_mini_object_copy(MiniObject mini_object);


### PR DESCRIPTION
In gstreamer 1.0 the gst_caps_ref and gst_caps_unref are `static inline`ed so in the shared library there are missing symbols for this methods. For reference: [https://github.com/GStreamer/gstreamer/blob/master/gst/gstcaps.h#L206](gstcaps.h).  
